### PR TITLE
Solve failure in the automatic download in #3

### DIFF
--- a/cmake/vocab_download.cmake
+++ b/cmake/vocab_download.cmake
@@ -13,7 +13,7 @@ if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vocab/mit_voc.yml)
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_SOURCE_DIR}/vocab.zip
                             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
     execute_process(COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_CURRENT_SOURCE_DIR}/vocab.zip)
-    message("[Kimera-Multi-LCD] Complete! Check your `${Kimera-Multi-LCD}/vocab/mit_voc.yml.")
+    message("[Kimera-Multi-LCD] Complete! Check your `${Kimera-Multi-LCD}/vocab/mit_voc.yml`.")
   else()
     message(FATAL_ERROR "[Kimera-Multi-LCD] Failed to download vocabulary file. Please download manually.")
   endif()

--- a/cmake/vocab_download.cmake
+++ b/cmake/vocab_download.cmake
@@ -3,7 +3,7 @@ message("[Kimera-Multi-LCD] Trying to download and unzip the vocabulary file..."
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vocab/mit_voc.yml)
   message("[Kimera-Multi-LCD] Downloading vocabulary file from drive.")
   file(DOWNLOAD
-       https://github.com/LimHyungTae/kimera-multi-vocab/raw/master/vocab.zip
+       https://github.com/MIT-SPARK/kimera-multi-vocab/raw/master/vocab.zip
        ${CMAKE_CURRENT_SOURCE_DIR}/vocab.zip
        STATUS voc_download_success
        )

--- a/cmake/vocab_download.cmake
+++ b/cmake/vocab_download.cmake
@@ -1,21 +1,22 @@
-### Download and unzip the vocabularly file
+### Download and unzip the vocabulary file
+message("[Kimera-Multi-LCD] Trying to download and unzip the vocabulary file...")
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vocab/mit_voc.yml)
-  message(STATUS "Downloading vocabulary file from drive.")
+  message("[Kimera-Multi-LCD] Downloading vocabulary file from drive.")
   file(DOWNLOAD
-       https://drive.google.com/uc?export=download&confirm=9iBg&id=1N4y0HbgA3PHQ73ZxFJvy5dgvV_0cTBYF
+       https://github.com/LimHyungTae/kimera-multi-vocab/raw/master/vocab.zip
        ${CMAKE_CURRENT_SOURCE_DIR}/vocab.zip
-       SHOW_PROGRESS
        STATUS voc_download_success
-       TIMEOUT 60)
+       )
   if(voc_download_success)
-    message(STATUS "Unzipping vocabulary file.")
+    message("[Kimera-Multi-LCD] Unzipping vocabulary file...")
 
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_SOURCE_DIR}/vocab.zip
                             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_SOURCE_DIR}/vocab.zip)
-  else(voc_download_success)
-    message(STATUS "Failed to download vocabulary file. Please download manually.")
-  endif(voc_download_success)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E rm ${CMAKE_CURRENT_SOURCE_DIR}/vocab.zip)
+    message("[Kimera-Multi-LCD] Complete! Check your `${Kimera-Multi-LCD}/vocab/mit_voc.yml.")
+  else()
+    message(FATAL_ERROR "[Kimera-Multi-LCD] Failed to download vocabulary file. Please download manually.")
+  endif()
 else()
-  message(STATUS "Vocabulary file exists, will not download.")
+  message("[Kimera-Multi-LCD] Vocabulary file exists, will not download.")
 endif()


### PR DESCRIPTION
Failure automatic issue was detoured by providing a specific filename in the personal repository (see [https://github.com/LimHyungTae/kimera-multi-vocab](https://github.com/LimHyungTae/kimera-multi-vocab))

It generally works as long as I don't change the repository to be private.

In addition, messages were not printed in the command line when we command `catkin build`, so I removed all the `STATUS` in the message, and fixed minor typo (ie., vocabularly- > vocabulary)